### PR TITLE
Global Cookie Path and Swagger Cookie Instances

### DIFF
--- a/servant-auth-swagger/src/Servant/Auth/Swagger.hs
+++ b/servant-auth-swagger/src/Servant/Auth/Swagger.hs
@@ -56,11 +56,17 @@ instance HasSecurity JWT where
 class AllHasSecurity (x :: [*]) where
   securities :: Proxy x -> [(T.Text,SecurityScheme)]
 
-instance (HasSecurity x, AllHasSecurity xs) => AllHasSecurity (x ': xs) where
+instance {-# OVERLAPPABLE #-} (HasSecurity x, AllHasSecurity xs) => AllHasSecurity (x ': xs) where
   securities _ = (securityName px, securityScheme px) : securities pxs
     where
       px :: Proxy x
       px = Proxy
+      pxs :: Proxy xs
+      pxs = Proxy
+
+instance {-# OVERLAPPING #-} AllHasSecurity xs => AllHasSecurity (Cookie ': xs) where
+  securities _ = securities pxs
+    where
       pxs :: Proxy xs
       pxs = Proxy
 


### PR DESCRIPTION
Hi Servant-Authors,

I've been writing a [little servant webapp](https://github.com/sordina/freewill.it#freewillai)
and have encountered two issues with the cookie auth behaviour in servant-auth.

The second is simple: There isn't a swagger AllHasSecurity instance for Cookie. After reading through the swagger docs and Haskell swagger issues, it looks like there's no good instance for this currently, but in order for our apps to use both swagger and cookies, we need something, so I've added an instance that simply ignores cookies for now. Another option would be to make the private module a public (Internal) module so that developers could add their own workaround instance.

The first is more interesting: The cookie settings from servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs use a default Nothing path. This sounds good, but according to the spec, clients should tie a cookie to the resource that generated it if a path isn't specified. This is bad for the expected behaviour of most web-apps, since you want to log-in once and have the cookie used for all resources. My workaround was to set the path to "/". This is probably fine for most use-cases, and should probably be the default, but it would also be nice to be able to pass a setting through, in case there was another setting that makes sense for a developer (an example could be nested sub-sites?).

Anyway, this is just a starting point. I'm happy to modify the pull request if it's not in great shape currently!

Let me know :)

 - Lyndon