### PR TITLE
RFC: Add check-origin method for CSRF

### DIFF
--- a/servant-auth-server/src/Servant/Auth/Server.hs
+++ b/servant-auth-server/src/Servant/Auth/Server.hs
@@ -67,13 +67,17 @@ module Servant.Auth.Server
 
   -- ** Settings
   , CookieSettings(..)
+  , XsrfCookieSettings(..)
   , defaultCookieSettings
+  , defaultXsrfCookieSettings
   , makeSessionCookie
   , makeSessionCookieBS
   , makeCsrfCookie
   , makeCookie
   , makeCookieBS
   , acceptLogin
+  , clearSession
+  , checkOriginAndReferer
 
 
   -- ** Related types

--- a/servant-auth-server/src/Servant/Auth/Server/Internal.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal.hs
@@ -53,7 +53,7 @@ instance ( n ~ 'S ('S 'Z)
 
       makeCookies :: AuthResult v -> IO (SetCookieList ('S ('S 'Z)))
       makeCookies authResult = do
-        csrf <- makeCsrfCookie cookieSettings
+        csrf <- makeXsrfCookie cookieSettings
         fmap (Just csrf `SetCookieCons`) $
           case authResult of
             (Authenticated v) -> do

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
@@ -3,16 +3,19 @@ module Servant.Auth.Server.Internal.Cookie where
 import           Blaze.ByteString.Builder (toByteString)
 import           Control.Monad.Except
 import           Control.Monad.Reader
-import qualified Crypto.JOSE              as Jose
-import qualified Crypto.JWT               as Jose
-import           Crypto.Util              (constTimeEq)
-import qualified Data.ByteString          as BS
-import qualified Data.ByteString.Base64   as BS64
-import qualified Data.ByteString.Lazy     as BSL
-import           Data.CaseInsensitive     (mk)
-import           Network.Wai              (requestHeaders)
-import           Servant                  (AddHeader, addHeader)
-import           System.Entropy           (getEntropy)
+import qualified Crypto.JOSE               as Jose
+import qualified Crypto.JWT                as Jose
+import           Crypto.Util               (constTimeEq)
+import qualified Data.ByteString           as BS
+import qualified Data.ByteString.Char8     as BSC
+import qualified Data.ByteString.Base64    as BS64
+import qualified Data.ByteString.Lazy      as BSL
+import           Data.CaseInsensitive      (mk)
+import           Data.Maybe                (fromMaybe, isJust)
+import           Network.HTTP.Types.Header (hCookie, hReferer)
+import           Network.Wai               (Request, requestHeaders)
+import           Servant                   (AddHeader, addHeader)
+import           System.Entropy            (getEntropy)
 import           Web.Cookie
 
 import Servant.Auth.Server.Internal.ConfigTypes
@@ -25,13 +28,19 @@ cookieAuthCheck :: FromJWT usr => CookieSettings -> JWTSettings -> AuthCheck usr
 cookieAuthCheck ccfg jwtCfg = do
   req <- ask
   jwtCookie <- maybe mempty return $ do
-    cookies' <- lookup "Cookie" $ requestHeaders req
+    cookies' <- lookup hCookie $ requestHeaders req
     let cookies = parseCookies cookies'
-    xsrfCookie <- lookup (xsrfCookieName ccfg) cookies
-    xsrfHeader <- lookup (mk $ xsrfHeaderName ccfg) $ requestHeaders req
-    guard $ xsrfCookie `constTimeEq` xsrfHeader
+
+    -- Apply the XSRF check if enabled.
+    guard $ case cookieXsrfSetting ccfg of
+      Just xsrfCookieSettings -> xsrfCookieAuthCheck xsrfCookieSettings req cookies
+      Nothing                 -> True
+
+    -- Apply the arbitrary request check from the configuration.
+    guard $ cookieCheckRequest ccfg req
+
     -- session cookie *must* be HttpOnly and Secure
-    lookup (sessionCookieName ccfg) cookies
+    lookup (cookieSessionCookieName ccfg) cookies
   verifiedJWT <- liftIO $ runExceptT $ do
     unverifiedJWT <- Jose.decodeCompact $ BSL.fromStrict jwtCookie
     Jose.verifyClaims (jwtSettingsToJwtValidationSettings jwtCfg)
@@ -43,20 +52,32 @@ cookieAuthCheck ccfg jwtCfg = do
       Left _ -> mzero
       Right v' -> return v'
 
--- | Makes a cookie to be used for CSRF.
+xsrfCookieAuthCheck :: XsrfCookieSettings -> Request -> [(BS.ByteString, BS.ByteString)] -> Bool
+xsrfCookieAuthCheck xsrfCookieCfg req cookies = fromMaybe False $ do
+  xsrfCookie <- lookup (xsrfCookieName xsrfCookieCfg) cookies
+  xsrfHeader <- lookup (mk $ xsrfHeaderName xsrfCookieCfg) $ requestHeaders req
+  return $ xsrfCookie `constTimeEq` xsrfHeader
+
+
+-- | Makes a cookie to be used for XSRF.
+makeXsrfCookie :: CookieSettings -> IO SetCookie
+makeXsrfCookie cookieSettings = case cookieXsrfSetting cookieSettings of
+  Just xsrfCookieSettings -> makeRealCookie xsrfCookieSettings
+  Nothing                 -> return $ noXsrfTokenCookie cookieSettings
+  where
+    makeRealCookie xsrfCookieSettings = do
+      xsrfValue <- BS64.encode <$> getEntropy 32
+      return
+        $ applyXsrfCookieSettings xsrfCookieSettings
+        $ applyCookieSettings cookieSettings
+        $ def{ setCookieValue = xsrfValue }
+
+
+-- | Alias for 'makeXsrfCookie'.
 makeCsrfCookie :: CookieSettings -> IO SetCookie
-makeCsrfCookie cookieSettings = do
-  csrfValue <- BS64.encode <$> getEntropy 32
-  return $ def
-    { setCookieName = xsrfCookieName cookieSettings
-    , setCookieValue = csrfValue
-    , setCookieMaxAge = cookieMaxAge cookieSettings
-    , setCookieExpires = cookieExpires cookieSettings
-    , setCookiePath = xsrfCookiePath cookieSettings
-    , setCookieSecure = case cookieIsSecure cookieSettings of
-        Secure -> True
-        NotSecure -> False
-    }
+makeCsrfCookie = makeXsrfCookie
+{-# DEPRECATED makeCsrfCookie "Use makeXsrfCookie instead" #-}
+
 
 -- | Makes a cookie with session information.
 makeSessionCookie :: ToJWT v => CookieSettings -> JWTSettings -> v -> IO (Maybe SetCookie)
@@ -64,17 +85,38 @@ makeSessionCookie cookieSettings jwtSettings v = do
   ejwt <- makeJWT v jwtSettings Nothing
   case ejwt of
     Left _ -> return Nothing
-    Right jwt -> return $ Just $ def
-      { setCookieName = sessionCookieName cookieSettings
-      , setCookieValue = BSL.toStrict jwt
-      , setCookieHttpOnly = True
-      , setCookieMaxAge = cookieMaxAge cookieSettings
-      , setCookieExpires = cookieExpires cookieSettings
-      , setCookiePath = cookiePath cookieSettings
-      , setCookieSecure = case cookieIsSecure cookieSettings of
-          Secure -> True
-          NotSecure -> False
-      }
+    Right jwt -> return
+      $ Just
+      $ applySessionCookieSettings cookieSettings
+      $ applyCookieSettings cookieSettings
+      $ def{ setCookieValue = BSL.toStrict jwt }
+
+noXsrfTokenCookie :: CookieSettings -> SetCookie
+noXsrfTokenCookie cookieSettings =
+  applyCookieSettings cookieSettings $ def{ setCookieName = "NO-XSRF-TOKEN", setCookieValue = "" }
+
+applyCookieSettings :: CookieSettings -> SetCookie -> SetCookie
+applyCookieSettings cookieSettings setCookie = setCookie
+  { setCookieMaxAge = cookieMaxAge cookieSettings
+  , setCookieExpires = cookieExpires cookieSettings
+  , setCookiePath = cookiePath cookieSettings
+  , setCookieSecure = case cookieIsSecure cookieSettings of
+      Secure -> True
+      NotSecure -> False
+  }
+
+applyXsrfCookieSettings :: XsrfCookieSettings -> SetCookie -> SetCookie
+applyXsrfCookieSettings xsrfCookieSettings setCookie = setCookie
+  { setCookieName = xsrfCookieName xsrfCookieSettings
+  , setCookiePath = xsrfCookiePath xsrfCookieSettings
+  , setCookieHttpOnly = False
+  }
+
+applySessionCookieSettings :: CookieSettings -> SetCookie -> SetCookie
+applySessionCookieSettings cookieSettings setCookie = setCookie
+  { setCookieName = cookieSessionCookieName cookieSettings
+  , setCookieHttpOnly = True
+  }
 
 -- | For a JWT-serializable session, returns a function that decorates a
 -- provided response object with CSRF and session cookies. This should be used
@@ -91,8 +133,31 @@ acceptLogin cookieSettings jwtSettings session = do
   case mSessionCookie of
     Nothing            -> pure Nothing
     Just sessionCookie -> do
-      csrfCookie <- makeCsrfCookie cookieSettings
-      return $ Just $ addHeader sessionCookie . addHeader csrfCookie
+      xsrfCookie <- makeXsrfCookie cookieSettings
+      return $ Just $ addHeader sessionCookie . addHeader xsrfCookie
+
+-- | Adds headers to a response that clears all session cookies.
+clearSession :: ( AddHeader "Set-Cookie" SetCookie response withOneCookie
+                , AddHeader "Set-Cookie" SetCookie withOneCookie withTwoCookies )
+             => CookieSettings
+             -> response
+             -> withTwoCookies
+clearSession cookieSettings
+  = addHeader (applySessionCookieSettings cookieSettings $ applyCookieSettings cookieSettings def)
+  . addHeader (noXsrfTokenCookie cookieSettings)
+
+-- | A helper for use with 'cookieCheckRequest' which verifies that either the request's @Origin@
+--   header or its @Referer@ header matches the expected origin. If neither header is available,
+--   this blockes the request.
+checkOriginAndReferer :: BS.ByteString -> Request -> Bool
+checkOriginAndReferer expectedOrigin req
+  =  (isJust origin || isJust referer)
+  && maybe True (expectedOrigin ==) origin
+  && maybe True (\x -> expectedOrigin == x || (expectedOrigin `BSC.snoc` '/') `BS.isPrefixOf` x) referer
+  where
+    headers = requestHeaders req
+    origin  = lookup "Origin" headers
+    referer = lookup hReferer headers
 
 makeSessionCookieBS :: ToJWT v => CookieSettings -> JWTSettings -> v -> IO (Maybe BS.ByteString)
 makeSessionCookieBS a b c = fmap (toByteString . renderSetCookie)  <$> makeSessionCookie a b c


### PR DESCRIPTION
Fixes #53 

This got me thinking: the CSRF protection could probably be entirely "pluggable". When it comes to security, you don't necessarily want that much flexibility though.

This doesn't pass tests yet but I wanted to see what you thought of the approach. I don't like how it sets an empty cookie just to get two set-cookie headers to make the types happy.