### PR TITLE
Make CSRF checks optional for GET requests (see #77)

### DIFF
--- a/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
@@ -65,6 +65,8 @@ data CookieSettings = CookieSettings
   , xsrfCookiePath    :: Maybe BS.ByteString
   -- | What name to use for the header used for CSRF protection.
   , xsrfHeaderName    :: BS.ByteString
+  -- | Exclude GET request method from CSRF protection.
+  , xsrfExcludeGet    :: Bool
   } deriving (Eq, Show, Generic)
 
 instance Default CookieSettings where
@@ -81,6 +83,7 @@ defaultCookieSettings = CookieSettings
     , xsrfCookieName    = "XSRF-TOKEN"
     , xsrfCookiePath    = Just "/"
     , xsrfHeaderName    = "X-XSRF-TOKEN"
+    , xsrfExcludeGet    = False
     }
 
 


### PR DESCRIPTION
The default is the same as before i.e. to perform CSRF checks for all methods
by setting {xsrfExcludeGet = True} the check can be disabled for GET

fixes #77