### PR TITLE
RFC: Add context to 'Token' and failure info to 'Indefinite'

### DIFF
--- a/servant-auth-client/servant-auth-client.cabal
+++ b/servant-auth-client/servant-auth-client.cabal
@@ -1,5 +1,5 @@
 name:           servant-auth-client
-version:        0.3.1.0
+version:        0.4.0.0
 synopsis:       servant-client/servant-auth compatibility
 description:    This package provides instances that allow generating clients from
                 <https://hackage.haskell.org/package/servant servant>
@@ -35,9 +35,9 @@ library
   ghc-options: -Wall
   build-depends:
       base                >= 4.8  && < 4.11
+    , http-api-data       >= 0.3  && < 0.3.8
     , text
-    , bytestring
-    , servant-auth        == 0.3.*
+    , servant-auth        == 0.4.*
     , servant             >= 0.7  && < 0.13
   if flag(servant-client-core)
     cpp-options: -DHAS_CLIENT_CORE=1

--- a/servant-auth-client/src/Servant/Auth/Client.hs
+++ b/servant-auth-client/src/Servant/Auth/Client.hs
@@ -1,3 +1,3 @@
-module Servant.Auth.Client (Token(..)) where
+module Servant.Auth.Client () where
 
-import Servant.Auth.Client.Internal (Token(..))
+import Servant.Auth.Client.Internal ()

--- a/servant-auth-docs/servant-auth-docs.cabal
+++ b/servant-auth-docs/servant-auth-docs.cabal
@@ -32,7 +32,7 @@ library
     , text
     , servant-docs
     , servant
-    , servant-auth == 0.3.*
+    , servant-auth >= 0.3 && < 0.5
     , lens
   exposed-modules:
       Servant.Auth.Docs

--- a/servant-auth-server/executables/README.lhs
+++ b/servant-auth-server/executables/README.lhs
@@ -64,7 +64,7 @@ type Protected
 
 
 -- | 'Protected' will be protected by 'auths', which we still have to specify.
-protected :: AuthResult User -> Server Protected
+protected :: AuthResult es User -> Server Protected
 -- If we get an "Authenticated v", we can trust the information in v, since
 -- it was signed by a key we trust.
 protected (Authenticated user) = return (name user) :<|> return (email user)

--- a/servant-auth-server/executables/README.lhs
+++ b/servant-auth-server/executables/README.lhs
@@ -24,7 +24,7 @@ data AuthResult val
   = BadPassword
   | NoSuchUser
   | Authenticated val
-  | Indefinite
+  | Indefinite [String]
 ~~~
 
 Your handlers will get a value of type `AuthResult Something`, and can decide

--- a/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth-server/servant-auth-server.cabal
@@ -1,5 +1,5 @@
 name:           servant-auth-server
-version:        0.3.1.0
+version:        0.4.0.0
 synopsis:       servant-server/servant-auth compatibility
 description:    This package provides the required instances for using the @Auth@ combinator
                 in your 'servant' server.
@@ -46,7 +46,7 @@ library
     , lens                    >= 4    && < 5
     , monad-time              >= 0.2  && < 0.3
     , mtl                     >= 2.2  && < 2.3
-    , servant-auth            == 0.3.*
+    , servant-auth            == 0.4.*
     , servant-server          >= 0.9.1  && < 0.13
     , tagged                  >= 0.7.3 && < 0.9
     , text                    >= 1    && < 2
@@ -108,6 +108,7 @@ test-suite spec
     , time
     , http-types
     , wai
+    , servant-auth
     , servant-server
 
   -- test dependencies

--- a/servant-auth-server/src/Servant/Auth/Server.hs
+++ b/servant-auth-server/src/Servant/Auth/Server.hs
@@ -21,6 +21,9 @@ module Servant.Auth.Server
     Auth
   , AuthResult(..)
   , AuthCheck(..)
+  , ErrorList (..)
+  , AuthsToErrors
+  , AuthError
 
   ----------------------------------------------------------------------------
   -- * JWT
@@ -46,6 +49,7 @@ module Servant.Auth.Server
   , ToJWT(..)
 
   -- ** Related types
+  , JWTAuthError(..)
   , IsMatch(..)
 
   -- ** Settings
@@ -77,6 +81,7 @@ module Servant.Auth.Server
 
 
   -- ** Related types
+  , CookieAuthError(..)
   , IsSecure(..)
 
   , AreAuths
@@ -94,6 +99,7 @@ module Servant.Auth.Server
   , BasicAuthCfg
 
   -- ** Related types
+  , BasicAuthError(..)
   , BasicAuthData(..)
   , IsPasswordCorrect(..)
 

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/BasicAuth.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/BasicAuth.hs
@@ -1,6 +1,8 @@
 module Servant.Auth.Server.Internal.BasicAuth where
 
 import qualified Data.ByteString                   as BS
+import           Data.Text                         (Text)
+import           GHC.Generics                      (Generic)
 import           Servant                           (BasicAuthData (..),
                                                     ServantErr (..), err401)
 import           Servant.Server.Internal.BasicAuth (decodeBAHdr,
@@ -21,9 +23,16 @@ class FromBasicAuthData a where
   -- Note that, rather than passing a 'Pass' to the function, we pass a
   -- function that checks an 'EncryptedPass'. This is to make sure you don't
   -- accidentally do something untoward with the password, like store it.
-  fromBasicAuthData :: BasicAuthData -> BasicAuthCfg -> IO (AuthResult a)
+  fromBasicAuthData :: BasicAuthData -> BasicAuthCfg -> IO (Either BasicAuthError a)
 
-basicAuthCheck :: FromBasicAuthData usr => BasicAuthCfg -> AuthCheck usr
+data BasicAuthError
+  = BasicAuthBadPassword
+  | BasicAuthNoSuchUser
+  | BasicAuthDecodingFailed
+  | BasicAuthOtherError Text
+  deriving (Eq, Generic, Show)
+
+basicAuthCheck :: FromBasicAuthData usr => BasicAuthCfg -> AuthCheck BasicAuthError usr
 basicAuthCheck cfg = AuthCheck $ \req -> case decodeBAHdr req of
-  Nothing -> pure $ fail "Failed basic auth decoding"
+  Nothing -> pure $ Left BasicAuthDecodingFailed
   Just baData -> fromBasicAuthData baData cfg

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/BasicAuth.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/BasicAuth.hs
@@ -25,5 +25,5 @@ class FromBasicAuthData a where
 
 basicAuthCheck :: FromBasicAuthData usr => BasicAuthCfg -> AuthCheck usr
 basicAuthCheck cfg = AuthCheck $ \req -> case decodeBAHdr req of
-  Nothing -> return Indefinite
+  Nothing -> pure $ fail "Failed basic auth decoding"
   Just baData -> fromBasicAuthData baData cfg

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/Class.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/Class.hs
@@ -1,49 +1,99 @@
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Servant.Auth.Server.Internal.Class where
 
-import Servant.Auth
-import Data.Monoid
+import Data.Proxy
+import GHC.Generics (Generic)
+import Network.Wai (Request)
 import Servant hiding (BasicAuth)
 
+import Servant.Auth
 import Servant.Auth.Server.Internal.Types
 import Servant.Auth.Server.Internal.ConfigTypes
 import Servant.Auth.Server.Internal.BasicAuth
 import Servant.Auth.Server.Internal.Cookie
 import Servant.Auth.Server.Internal.JWT
 
+-- | The result of running the auths 'as'
+data AuthResult auths v
+  = Authenticated v
+  | AuthFailed (ErrorList (AuthsToErrors auths))
+  deriving (Generic, Functor, Traversable, Foldable)
+
+deriving instance (Eq v, Eq (ErrorList (AuthsToErrors auths)))
+  => Eq (AuthResult auths v)
+deriving instance (Show v, Show (ErrorList (AuthsToErrors auths)))
+  => Show (AuthResult auths v)
+
+
+-- | Open type family
+type family AuthsToErrors (auths :: [*]) = (errs :: [*]) | errs -> auths where
+  AuthsToErrors '[] = '[]
+  AuthsToErrors (a ': auths) = AuthError a ': AuthsToErrors auths
+
+-- | HList as a GADT. Named differently to prevent clash with servant's HList
+data ErrorList (as :: [*]) where
+  ENil :: ErrorList '[]
+  ECons :: a -> ErrorList as -> ErrorList (a ': as)
+
+instance Show (ErrorList '[]) where
+  show ENil = "ENil"
+instance (Show a, Show (ErrorList as)) => Show (ErrorList (a ': as)) where
+  show (ECons a as) = show a ++ " ': " ++ show as
+
+instance Eq (ErrorList '[]) where
+  ENil == ENil = True
+instance (Eq a, Eq (ErrorList as)) => Eq (ErrorList (a ': as)) where
+  ECons a as == ECons a' as' = a == a' && as == as'
+
 -- | @IsAuth a ctx v@ indicates that @a@ is an auth type that expects all
 -- elements of @ctx@ to be the in the Context and whose authentication check
 -- returns an @AuthCheck v@.
-class IsAuth a v  where
+class IsAuth a v where
+  type family AuthError a = (err :: *) | err -> a
   type family AuthArgs a :: [*]
-  runAuth :: proxy a -> proxy v -> Unapp (AuthArgs a) (AuthCheck v)
+  runAuth :: proxy a -> proxy v
+          -> Unapp (AuthArgs a) (AuthCheck (AuthError a) v)
 
 instance FromJWT usr => IsAuth Cookie usr where
   type AuthArgs Cookie = '[CookieSettings, JWTSettings]
+  type AuthError Cookie = CookieAuthError
   runAuth _ _ = cookieAuthCheck
 
 instance FromJWT usr => IsAuth JWT usr where
   type AuthArgs JWT = '[JWTSettings]
+  type AuthError JWT = JWTAuthError
   runAuth _ _ = jwtAuthCheck
 
 instance FromBasicAuthData usr => IsAuth BasicAuth usr where
   type AuthArgs BasicAuth = '[BasicAuthCfg]
+  type AuthError BasicAuth = BasicAuthError
   runAuth _ _ = basicAuthCheck
 
 -- * Helper
 
+-- | Helper for running many auth checks
 class AreAuths (as :: [*]) (ctxs :: [*]) v where
-  runAuths :: proxy as -> Context ctxs -> AuthCheck v
+  runAuths :: proxy as -> Context ctxs -> Request
+           -> IO (AuthResult as v)
 
 instance  AreAuths '[] ctxs v where
-  runAuths _ _ = mempty
+  runAuths _ _ _ = pure $ AuthFailed ENil
 
-instance ( AuthCheck v ~ App (AuthArgs a) (Unapp (AuthArgs a) (AuthCheck v))
+-- | Convenience function
+addFailed :: AuthError e -> AuthResult es a -> AuthResult (e ': es) a
+addFailed e (AuthFailed es) = AuthFailed $ ECons e es
+addFailed _ (Authenticated a) = Authenticated a
+
+instance ( AuthCheck (AuthError a) v ~ App (AuthArgs a) (Unapp (AuthArgs a) (AuthCheck (AuthError a) v))
          , IsAuth a v
          , AreAuths as ctxs v
-         , AppCtx ctxs (AuthArgs a) (Unapp (AuthArgs a) (AuthCheck v))
+         , AppCtx ctxs (AuthArgs a) (Unapp (AuthArgs a) (AuthCheck (AuthError a) v))
          ) => AreAuths (a ': as) ctxs v where
-  runAuths _ ctxs = go <> runAuths (Proxy :: Proxy as) ctxs
+  runAuths _ ctxs req = runAuthCheck go req >>= \x -> case x of
+    Left e -> addFailed e <$> runAuths (Proxy :: Proxy as) ctxs req
+    Right a -> pure $ Authenticated a
     where
       go = appCtx (Proxy :: Proxy (AuthArgs a))
                   ctxs

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/Types.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/Types.hs
@@ -1,105 +1,42 @@
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Servant.Auth.Server.Internal.Types where
 
-import Control.Applicative
 import Control.Monad.Reader
 import Control.Monad.Time
-import Data.Semigroup
 import Data.Time            (getCurrentTime)
 import GHC.Generics         (Generic)
 import Network.Wai          (Request)
 
--- | The result of an authentication attempt.
-data AuthResult val
-  = BadPassword
-  | NoSuchUser
-  -- | Authentication succeeded.
-  | Authenticated val
-  -- | If an authentication procedure cannot be carried out - if for example it
-  -- expects a password and username in a header that is not present -
-  -- @Indefinite@ is returned. This indicates that other authentication
-  -- methods should be tried.
-  | Indefinite [String]
-  deriving (Eq, Show, Read, Generic, Ord, Functor, Traversable, Foldable)
-
-instance Semigroup (AuthResult val) where
-  Authenticated v <> _ = Authenticated v
-  _ <> Authenticated v = Authenticated v
-  Indefinite e <> Indefinite e' = Indefinite $ e ++ e'
-  Indefinite _ <> x = x
-  x <> _ = x
-
-instance Monoid (AuthResult val) where
-  mempty = fail "mempty"
-  mappend = (<>)
-
-instance Applicative AuthResult where
-  pure = Authenticated
-  (<*>) = ap
-
-instance Monad AuthResult where
-  return = pure
-  fail = Indefinite . pure
-  Authenticated v >>= f = f v
-  BadPassword  >>= _ = BadPassword
-  NoSuchUser   >>= _ = NoSuchUser
-  Indefinite e >>= _ = Indefinite e
-
-instance Alternative AuthResult where
-  empty = fail "empty"
-  (<|>) = mplus
-
-instance MonadPlus AuthResult where
-  mzero = fail "mzero"
-  mplus = (<>)
-
-
 -- | An @AuthCheck@ is the function used to decide the authentication status
--- (the 'AuthResult') of a request. Different @AuthCheck@s may be combined as a
--- Monoid or Alternative; the semantics of this is that the *first*
--- non-'Indefinite' result from left to right is used.
-newtype AuthCheck val = AuthCheck
-  { runAuthCheck :: Request -> IO (AuthResult val) }
+-- of a request.
+newtype AuthCheck err val = AuthCheck
+  { runAuthCheck :: Request -> IO (Either err val) }
   deriving (Generic, Functor)
 
-instance Semigroup (AuthCheck val) where
-  AuthCheck f <> AuthCheck g = AuthCheck $ \x -> do
-    fx <- f x
-    gx <- g x
-    return $ fx <> gx
-
-instance Monoid (AuthCheck val) where
-  mempty = AuthCheck $ const $ return mempty
-  mappend = (<>)
-
-instance Applicative AuthCheck where
+instance Applicative (AuthCheck err) where
   pure = AuthCheck . pure . pure . pure
   (<*>) = ap
 
-instance Monad AuthCheck where
+failWith :: err -> AuthCheck err a
+failWith = AuthCheck . const . pure . Left
+
+instance Monad (AuthCheck err) where
   return = pure
-  fail e = AuthCheck . const $ return $ Indefinite [e]
   AuthCheck ac >>= f = AuthCheck $ \req -> do
     aresult <- ac req
     case aresult of
-      Authenticated usr -> runAuthCheck (f usr) req
-      BadPassword       -> return BadPassword
-      NoSuchUser        -> return NoSuchUser
-      Indefinite e      -> return $ Indefinite e
+      Right usr -> runAuthCheck (f usr) req
+      Left e -> pure $ Left e
 
-instance MonadReader Request AuthCheck where
-  ask = AuthCheck $ \x -> return (Authenticated x)
+instance MonadReader Request (AuthCheck err) where
+  ask = AuthCheck $ pure . Right
   local f (AuthCheck check) = AuthCheck $ \req -> check (f req)
 
-instance MonadIO AuthCheck where
-  liftIO action = AuthCheck $ const $ Authenticated <$> action
+instance MonadIO (AuthCheck err) where
+  liftIO action = AuthCheck $ const $ Right <$> action
 
-instance MonadTime AuthCheck where
+instance MonadTime (AuthCheck err) where
   currentTime = liftIO getCurrentTime
 
-instance Alternative AuthCheck where
-  empty = mzero
-  (<|>) = mplus
-
-instance MonadPlus AuthCheck where
-  mzero = mempty
-  mplus = (<>)

--- a/servant-auth-swagger/servant-auth-swagger.cabal
+++ b/servant-auth-swagger/servant-auth-swagger.cabal
@@ -29,7 +29,7 @@ library
     , servant-swagger
     , swagger2 >= 2 && < 3
     , servant
-    , servant-auth == 0.3.*
+    , servant-auth >= 0.3 && < 0.5
     , lens
   exposed-modules:
       Servant.Auth.Swagger

--- a/servant-auth/servant-auth.cabal
+++ b/servant-auth/servant-auth.cabal
@@ -1,5 +1,5 @@
 name:           servant-auth
-version:        0.3.0.1
+version:        0.4.0.0
 synopsis:       Authentication combinators for servant
 description:    This package provides an @Auth@ combinator for 'servant'. This combinator
                 allows using different authentication schemes in a straightforward way,
@@ -31,7 +31,12 @@ library
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base >= 4.8 && < 4.11
+      base                    >= 4.8  && < 4.11
+    , base64-bytestring       >= 1    && < 2
+    , bytestring              >= 0.10 && < 0.11
+    , crypto-api              >= 0.13 && < 0.14
+    , http-api-data           >= 0.3  && < 0.3.8
+    , text                    >= 1    && < 2
   exposed-modules:
       Servant.Auth
   default-language: Haskell2010

--- a/servant-auth/src/Servant/Auth.hs
+++ b/servant-auth/src/Servant/Auth.hs
@@ -8,7 +8,7 @@ import Crypto.Util (constTimeEq)
 import Data.Semigroup ((<>))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as B64
-import Data.Text.Encoding (encodeUtf8, decodeLatin1)
+import Data.Text.Encoding (encodeUtf8, decodeUtf8)
 import Web.HttpApiData
 
 -- | A compact JWT Token.
@@ -32,7 +32,7 @@ textToBs :: Text -> BS.ByteString
 textToBs = B64.decodeLenient . encodeUtf8
 
 bsToText :: BS.ByteString -> Text
-bsToText = decodeLatin1 . B64.encode
+bsToText = decodeUtf8 . B64.encode
 
 -- * Authentication
 


### PR DESCRIPTION
- Move 'Token' to 'servant-auth' from 'servant-auth-client', and add a phantom type parameter indicating what is contained in that token. I've found this is particularly handy as an end user when there are a few different tokens around.
- Adding "Bearer " to the auth header is handled in the To/FromHttpApiData instances for 'Token', for simplification. I'm not aware of a case this shouldn't be done.
- Factored out some common code between cookie and jwt checks into 'parseJWT'
- Change 'Indefinite' so that it carries data about the failure, modified the implementations of cookie/jwt checks to add extra info (addresses issue #78). This should perhaps be changed from a list of strings to some custom 'ServantAuthError' sum type so that users can pattern match on failures.
- Add Semigroup instance for 'AuthCheck' and 'AuthResult' to fix GHC warnings

I also tentatively changed the version to 0.4.0.0 given that this is a breaking change.