### PR TITLE
Disallow wreq >= 0.5.2.0 on GHC 7.10 in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,16 +33,20 @@ matrix:
     - compiler: "ghc-7.10.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-7.10.3], sources: [hvr-ghc]}}
+      env: EXTRA_CABAL_ARGS="--constraint=wreq==0.5.1.1"
     - compiler: "ghc-8.0.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.0.2], sources: [hvr-ghc]}}
+      env: EXTRA_CABAL_ARGS=""
     - compiler: "ghc-8.2.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.1], sources: [hvr-ghc]}}
+      env: EXTRA_CABAL_ARGS=""
 
 before_install:
   - HC=${CC}
   - HCPKG=${HC/ghc/ghc-pkg}
+  - ECA=${EXTRA_CABAL_ARGS}
   - unset CC
   - PATH=/opt/ghc/bin:/opt/ghc-ppa-tools/bin:$PATH
 
@@ -72,8 +76,8 @@ install:
       (cd "servant-auth-swagger"; autoreconf -i);
     fi
   - rm -f cabal.project.freeze
-  - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
-  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
+  - cabal new-build -w ${HC} ${TEST} ${BENCH} ${ECA} --project-file="cabal.project" --dep -j2 all
+  - cabal new-build -w ${HC} ${ECA} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
   - rm -rf .ghc.environment.* "servant-auth-client"/dist "servant-auth-docs"/dist "servant-auth"/dist "servant-auth-server"/dist "servant-auth-swagger"/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
 
@@ -102,13 +106,13 @@ script:
   - echo Building with installed constraints for package in global-db... && echo -en 'travis_fold:start:build-installed\\r'
   # Build with installed constraints for packages in global-db
   - if $INSTALLED; then
-      echo cabal new-build -w ${HC} --disable-tests --disable-benchmarks $(${HCPKG} list --global --simple-output --names-only | sed 's/\([a-zA-Z0-9-]\{1,\}\) */--constraint="\1 installed" /g') all | sh;
+      echo cabal new-build -w ${HC} ${ECA} --disable-tests --disable-benchmarks $(${HCPKG} list --global --simple-output --names-only | sed 's/\([a-zA-Z0-9-]\{1,\}\) */--constraint="\1 installed" /g') all | sh;
     else echo "Not building with installed constraints"; fi
   - echo -en 'travis_fold:end:build-installed\\r'
 
   - echo Building with tests and benchmarks... && echo -en 'travis_fold:start:build-everything\\r'
   # build & run tests, build benchmarks
-  - cabal new-build -w ${HC} ${TEST} ${BENCH} all
+  - cabal new-build -w ${HC} ${TEST} ${BENCH} ${ECA} all
   - echo -en 'travis_fold:end:build-everything\\r'
   - echo Testing... && echo -en 'travis_fold:start:test\\r'
   - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} all; fi


### PR DESCRIPTION
    Since that version of wreq is incompatible with Cabal 1.22.