### PR TITLE
Disable the readme executable for ghcjs builds

### DIFF
--- a/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth-server/servant-auth-server.cabal
@@ -86,6 +86,8 @@ executable readme
     , transformers
     , markdown-unlit
   default-language: Haskell2010
+  if impl(ghcjs)
+    buildable: False
 
 test-suite spec
   type: exitcode-stdio-1.0


### PR DESCRIPTION
It has trouble dealing with the .lhs file.