### PR TITLE
Validate JWT against a JWKSet instead of JWK

### DIFF
--- a/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
@@ -29,6 +29,8 @@ data SameSite = AnySite | SameSiteStrict | SameSiteLax
 data JWTSettings = JWTSettings
   { key             :: Jose.JWK
   , jwtAlg          :: Maybe Jose.Alg
+  -- | Keys used to validate JWT.
+  , keySet          :: Jose.JWKSet
   -- | An @aud@ predicate. The @aud@ is a string or URI that identifies the
   -- intended recipient of the JWT.
   , audienceMatches :: Jose.StringOrURI -> IsMatch
@@ -37,9 +39,10 @@ data JWTSettings = JWTSettings
 -- | A @JWTSettings@ where the audience always matches.
 defaultJWTSettings :: Jose.JWK -> JWTSettings
 defaultJWTSettings k = JWTSettings
-  { key = k
-  , jwtAlg = Nothing
-  , audienceMatches = const Matches }
+   { key = k
+   , jwtAlg = Nothing
+   , keySet = Jose.JWKSet [k]
+   , audienceMatches = const Matches }
 
 -- | The policies to use when generating cookies.
 --

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
@@ -27,10 +27,13 @@ data SameSite = AnySite | SameSiteStrict | SameSiteLax
 
 -- | @JWTSettings@ are used to generate cookies, and to verify JWTs.
 data JWTSettings = JWTSettings
-  { key             :: Jose.JWK
+  {
+  -- | Key used to sign JWT.
+    signingKey      :: Jose.JWK
+  -- | Algorithm used to sign JWT.
   , jwtAlg          :: Maybe Jose.Alg
   -- | Keys used to validate JWT.
-  , keySet          :: Jose.JWKSet
+  , validationKeys  :: Jose.JWKSet
   -- | An @aud@ predicate. The @aud@ is a string or URI that identifies the
   -- intended recipient of the JWT.
   , audienceMatches :: Jose.StringOrURI -> IsMatch
@@ -39,9 +42,9 @@ data JWTSettings = JWTSettings
 -- | A @JWTSettings@ where the audience always matches.
 defaultJWTSettings :: Jose.JWK -> JWTSettings
 defaultJWTSettings k = JWTSettings
-   { key = k
+   { signingKey = k
    , jwtAlg = Nothing
-   , keySet = Jose.JWKSet [k]
+   , validationKeys = Jose.JWKSet [k]
    , audienceMatches = const Matches }
 
 -- | The policies to use when generating cookies.

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
@@ -40,7 +40,7 @@ cookieAuthCheck ccfg jwtCfg = do
   verifiedJWT <- liftIO $ runExceptT $ do
     unverifiedJWT <- Jose.decodeCompact $ BSL.fromStrict jwtCookie
     Jose.verifyClaims (jwtSettingsToJwtValidationSettings jwtCfg)
-                      (key jwtCfg)
+                      (keySet jwtCfg)
                       unverifiedJWT
   case verifiedJWT of
     Left (_ :: Jose.JWTError) -> mzero

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
@@ -40,7 +40,7 @@ cookieAuthCheck ccfg jwtCfg = do
   verifiedJWT <- liftIO $ runExceptT $ do
     unverifiedJWT <- Jose.decodeCompact $ BSL.fromStrict jwtCookie
     Jose.verifyClaims (jwtSettingsToJwtValidationSettings jwtCfg)
-                      (keySet jwtCfg)
+                      (validationKeys jwtCfg)
                       unverifiedJWT
   case verifiedJWT of
     Left (_ :: Jose.JWTError) -> mzero

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/JWT.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/JWT.hs
@@ -57,7 +57,7 @@ jwtAuthCheck config = do
   verifiedJWT <- liftIO $ runExceptT $ do
     unverifiedJWT <- Jose.decodeCompact $ BSL.fromStrict token
     Jose.verifyClaims (jwtSettingsToJwtValidationSettings config)
-                      (keySet config)
+                      (validationKeys config)
                       unverifiedJWT
   case verifiedJWT of
     Left (_ :: Jose.JWTError) -> mzero
@@ -73,9 +73,9 @@ jwtAuthCheck config = do
 makeJWT :: ToJWT a
   => a -> JWTSettings -> Maybe UTCTime -> IO (Either Jose.Error BSL.ByteString)
 makeJWT v cfg expiry = runExceptT $ do
-  bestAlg <- Jose.bestJWSAlg $ key cfg
+  bestAlg <- Jose.bestJWSAlg $ signingKey cfg
   let alg = fromMaybe bestAlg $ jwtAlg cfg
-  ejwt <- Jose.signClaims (key cfg)
+  ejwt <- Jose.signClaims (signingKey cfg)
                           (Jose.newJWSHeader ((), alg))
                           (addExp $ encodeJWT v)
 

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/JWT.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/JWT.hs
@@ -57,7 +57,7 @@ jwtAuthCheck config = do
   verifiedJWT <- liftIO $ runExceptT $ do
     unverifiedJWT <- Jose.decodeCompact $ BSL.fromStrict token
     Jose.verifyClaims (jwtSettingsToJwtValidationSettings config)
-                      (key config)
+                      (keySet config)
                       unverifiedJWT
   case verifiedJWT of
     Left (_ :: Jose.JWTError) -> mzero


### PR DESCRIPTION
This is useful if you rotate keys with short expiration time.
