### PR TITLE
servant-auth-swagger: add Cookie to the test

### DIFF
--- a/servant-auth-swagger/test/Servant/Auth/SwaggerSpec.hs
+++ b/servant-auth-swagger/test/Servant/Auth/SwaggerSpec.hs
@@ -3,6 +3,7 @@ module Servant.Auth.SwaggerSpec (spec) where
 import Control.Lens
 import Data.Proxy
 import Servant.API
+import Servant.Auth
 import Servant.Auth.Swagger
 import Data.Swagger
 import Servant.Swagger
@@ -23,7 +24,7 @@ spec = describe "HasSwagger instance" $ do
 
 -- * API
 
-type API =   "secure" :> Auth '[JWT] Int :> SecureAPI
+type API =   "secure" :> Auth '[JWT, Cookie] Int :> SecureAPI
         :<|> "insecure" :> InsecureAPI
 
 type SecureAPI = Get '[JSON] Int :<|> ReqBody '[JSON] Int :> Post '[JSON] Int

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,6 +12,7 @@ extra-deps:
 - servant-docs-0.11.2
 - servant-server-0.13
 - servant-swagger-1.1.5
+- http-api-data-0.3.8.1
 - http-types-0.12.1
 - text-1.2.3.0
 resolver: lts-10.6


### PR DESCRIPTION
Since the Cookie instance doesn't add any docs, I didn't think of what else could we check.

PS: without the stack.yaml the project wouldn't compile.