### PR TITLE
Make cookies expire serverside

### DIFF
--- a/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
@@ -84,7 +84,7 @@ makeCsrfCookie = makeXsrfCookie
 -- | Makes a cookie with session information.
 makeSessionCookie :: ToJWT v => CookieSettings -> JWTSettings -> v -> IO (Maybe SetCookie)
 makeSessionCookie cookieSettings jwtSettings v = do
-  ejwt <- makeJWT v jwtSettings Nothing
+  ejwt <- makeJWT v jwtSettings (cookieExpires cookieSettings)
   case ejwt of
     Left _ -> return Nothing
     Right jwt -> return


### PR DESCRIPTION
Currently the JWT session cookie does not expire, it should be set to expire to enforce serverside cookie expiration.

If an attacker were to get there hands on a JWT cookie, they could use it to stay authenticated until the server's JWT key is changed.

This PR allows you to make the cookie expire by setting the cookieExpires field of cookieSettings, but this is an absolute time argument, and would need to be different for each issued cookie.

A better solution might be to use the cookieMaxAge field (which is DiffTime) to generate the expiration time for the JWT. Its probably also a good idea to set the default cookieMaxAge to something like 30 days. If you think this is a good idea I can modify the PR as necessary.