### PR TITLE
makeJWT: allow setting Alg via defaultJWTSettings

### DIFF
--- a/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
@@ -28,6 +28,7 @@ data SameSite = AnySite | SameSiteStrict | SameSiteLax
 -- | @JWTSettings@ are used to generate cookies, and to verify JWTs.
 data JWTSettings = JWTSettings
   { key             :: Jose.JWK
+  , jwtAlg          :: Maybe Jose.Alg
   -- | An @aud@ predicate. The @aud@ is a string or URI that identifies the
   -- intended recipient of the JWT.
   , audienceMatches :: Jose.StringOrURI -> IsMatch
@@ -35,7 +36,10 @@ data JWTSettings = JWTSettings
 
 -- | A @JWTSettings@ where the audience always matches.
 defaultJWTSettings :: Jose.JWK -> JWTSettings
-defaultJWTSettings k = JWTSettings { key = k, audienceMatches = const Matches }
+defaultJWTSettings k = JWTSettings
+  { key = k
+  , jwtAlg = Nothing
+  , audienceMatches = const Matches }
 
 -- | The policies to use when generating cookies.
 --

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/JWT.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/JWT.hs
@@ -11,6 +11,7 @@ import           Data.Aeson           (FromJSON, Result (..), ToJSON, fromJSON,
 import qualified Data.ByteString      as BS
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.HashMap.Strict  as HM
+import           Data.Maybe           (fromMaybe)
 import qualified Data.Text            as T
 import           Data.Time            (UTCTime)
 import           Network.Wai          (requestHeaders)
@@ -72,7 +73,8 @@ jwtAuthCheck config = do
 makeJWT :: ToJWT a
   => a -> JWTSettings -> Maybe UTCTime -> IO (Either Jose.Error BSL.ByteString)
 makeJWT v cfg expiry = runExceptT $ do
-  alg <- Jose.bestJWSAlg $ key cfg
+  bestAlg <- Jose.bestJWSAlg $ key cfg
+  let alg = fromMaybe bestAlg $ jwtAlg cfg
   ejwt <- Jose.signClaims (key cfg)
                           (Jose.newJWSHeader ((), alg))
                           (addExp $ encodeJWT v)


### PR DESCRIPTION
Default algorithm generates pretty long tokens, I'd prefer using HS256 and this PR allows to do that.