### PR TITLE
Enable library to work with jose-0.7.0.0

### DIFF
--- a/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth-server/servant-auth-server.cabal
@@ -42,7 +42,7 @@ library
     , entropy                 >= 0.3  && < 0.5
     , http-api-data           >= 0.3.8 && < 0.4
     , http-types              >= 0.9  && < 0.13
-    , jose                    >= 0.6  && < 0.7
+    , jose                    >= 0.6  && < 0.8
     , lens                    >= 4    && < 5
     , monad-time              >= 0.2  && < 0.3
     , mtl                     >= 2.2  && < 2.3

--- a/stack-ghc-7.10.3.yaml
+++ b/stack-ghc-7.10.3.yaml
@@ -16,7 +16,7 @@ extra-deps:
 - hspec-expectations-0.8.2
 - http-api-data-0.3.3
 - concise-0.1.0.0
-- jose-0.6.0.3
+- jose-0.7.0.0
 - mmorph-1.0.9
 - servant-0.9.1.1
 - servant-client-0.9.1.1

--- a/stack-ghc-8.2.1.yaml
+++ b/stack-ghc-8.2.1.yaml
@@ -7,7 +7,7 @@ packages:
 - servant-auth-docs
 - servant-auth-swagger
 extra-deps:
-- jose-0.6.0.3
+- jose-0.7.0.0
 - servant-0.11
 - servant-client-0.11
 - servant-docs-0.10.0.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,4 +15,5 @@ extra-deps:
 - http-api-data-0.3.8.1
 - http-types-0.12.1
 - text-1.2.3.0
+- jose-0.7.0.0
 resolver: lts-10.6


### PR DESCRIPTION
I'd like to use `verifyClaimsAt` from `jose-0.7` in my code.

Disclaimer: I have no idea what I'm doing.

The last upgrade (to 0.6) was done here: https://github.com/xaviershay/servant-auth/commit/280090e1ba4523c1c2eaae3865c569b2f7bbae9a

* It renames and modifies the GHC version specific stack files. I guess the idea here is to just rename them to "latest" GHC? I notice that changing them wasn't sufficient to pick up the new dependency, which is why I added it to the default `stack.yaml`. I'm not sure whether jose 0.7 is compatible with GHC 7 and am not sure how to dual host GHC to test.
* I left the lower bound of jose at `0.6` to be conservative, since I have no idea whether there are reasons people wouldn't want to upgrade, and since I didn't change this library to use any new features.
* The only verification I did was ensuring that `stack test` passed.

Thanks!