### PR TITLE
Avoid running auth checks unnecessarily

### DIFF
--- a/servant-auth-server/src/Servant/Auth/Server/Internal/Types.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/Types.hs
@@ -61,8 +61,9 @@ newtype AuthCheck val = AuthCheck
 instance Semigroup (AuthCheck val) where
   AuthCheck f <> AuthCheck g = AuthCheck $ \x -> do
     fx <- f x
-    gx <- g x
-    return $ fx <> gx
+    case fx of
+      Indefinite -> g x
+      r -> pure r
 
 instance Monoid (AuthCheck val) where
   mempty = AuthCheck $ const $ return mempty


### PR DESCRIPTION
Checks made after first not Indefinite result are ignored in Semigroup instance.

With this change change we avoid running checks whose results will be thrown out later.

Another advantage of this change is ability to specifying more expensive checks after cheaper checks, and avoiding running more expensive ones if cheaper succeeds.
For example you may have "access token"-like cookie which times out with session and does not require DB access, and optional "remember-me" cookie which does requires DB access. With this change you can avoid accessing DB while session cookie is still alive.

This is a breaking change for users who have side-effecting auth checks that rely on the fact that all checks are run on each request.