### PR TITLE
Session cookie didn't apply SameSite attribute

### DIFF
--- a/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
@@ -116,6 +116,10 @@ applyXsrfCookieSettings xsrfCookieSettings setCookie = setCookie
 applySessionCookieSettings :: CookieSettings -> SetCookie -> SetCookie
 applySessionCookieSettings cookieSettings setCookie = setCookie
   { setCookieName = sessionCookieName cookieSettings
+  , setCookieSameSite = case cookieSameSite cookieSettings of
+      AnySite -> Nothing
+      SameSiteStrict -> Just sameSiteStrict
+      SameSiteLax -> Just sameSiteLax
   , setCookieHttpOnly = True
   }
 


### PR DESCRIPTION
This means previously, protection of the cookie wasn't applied. 

cc @3noch 