### PR TITLE
[#114] Export `HasSecurity` typeclass

### DIFF
--- a/servant-auth-swagger/src/Servant/Auth/Swagger.hs
+++ b/servant-auth-swagger/src/Servant/Auth/Swagger.hs
@@ -10,6 +10,9 @@ module Servant.Auth.Swagger
     JWT
   , BasicAuth
   , Auth
+
+  -- * Needed to define instances of @HasSwagger@
+  , HasSecurity (..)
   ) where
 
 import Control.Lens    ((&), (<>~))


### PR DESCRIPTION
Closes #114.

From what I can understand, in order to define a [`HasSwagger` instance for an API that has an authentication method](https://github.com/haskell-servant/servant-auth/blob/master/servant-auth-swagger/src/Servant/Auth/Swagger.hs#L28), an `AllHasSecurity` instance is required for the authentication method, which can be built incrementally for the intended service from [these](https://github.com/haskell-servant/servant-auth/blob/master/servant-auth-swagger/src/Servant/Auth/Swagger.hs#L59) [two](https://github.com/haskell-servant/servant-auth/blob/master/servant-auth-swagger/src/Servant/Auth/Swagger.hs#L73) instances.

For this method to work, `HasSecurity` has to be exported (the previous two instances are exported automatically), which is what this PR does.