### PR TITLE
Fix #144: servant-0.16 support in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,6 @@ matrix:
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.2.2], sources: [hvr-ghc]}}
     - compiler: "ghc-8.0.2"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.0.2], sources: [hvr-ghc]}}
-    - compiler: "ghc-7.10.3"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-7.10.3], sources: [hvr-ghc]}}
 
 before_install:
   - HC=/opt/ghc/bin/${CC}

--- a/servant-auth-client/servant-auth-client.cabal
+++ b/servant-auth-client/servant-auth-client.cabal
@@ -15,7 +15,7 @@ maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
 license:        BSD3
 license-file:   LICENSE
-tested-with:    GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:    GHC == 8.0.2, GHC == 8.2.2, GHC==8.4.4, GHC==8.6.2
 build-type:     Simple
 cabal-version:  >= 1.10
 extra-source-files:
@@ -31,7 +31,7 @@ library
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base                >= 4.8      && < 4.13
+      base                >= 4.9      && < 4.13
     , bytestring          >= 0.10.6.0 && < 0.11
     , containers          >= 0.5.6.2  && < 0.7
     , servant-auth        == 0.3.*

--- a/servant-auth-client/servant-auth-client.cabal
+++ b/servant-auth-client/servant-auth-client.cabal
@@ -69,7 +69,7 @@ test-suite spec
     , http-client          >= 0.5.13.1 && < 0.7
     , http-types           >= 0.12.2   && < 0.13
     , servant-auth-server  >= 0.4.2.0  && < 0.5
-    , servant-server       >= 0.13     && < 0.16
+    , servant-server       >= 0.13     && < 0.17
     , time                 >= 1.5.0.1  && < 1.9
     , transformers         >= 0.4.2.0  && < 0.6
     , wai                  >= 3.2.1.2  && < 3.3

--- a/servant-auth-docs/servant-auth-docs.cabal
+++ b/servant-auth-docs/servant-auth-docs.cabal
@@ -15,7 +15,7 @@ maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
 license:        BSD3
 license-file:   LICENSE
-tested-with:    GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:    GHC == 8.0.2, GHC == 8.2.2, GHC==8.4.4, GHC==8.6.2
 build-type:     Custom
 cabal-version:  >= 1.10
 extra-source-files:
@@ -35,7 +35,7 @@ library
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base         >= 4.8     && < 4.13
+      base         >= 4.9     && < 4.13
     , servant-docs >= 0.11.2  && < 0.12
     , servant      >= 0.13    && < 0.17
     , servant-auth == 0.3.*

--- a/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth-server/servant-auth-server.cabal
@@ -15,7 +15,7 @@ maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
 license:        BSD3
 license-file:   LICENSE
-tested-with:    GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.2
+tested-with:    GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.2
 build-type:     Simple
 cabal-version:  >= 1.10
 extra-source-files:
@@ -31,7 +31,7 @@ library
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base                    >= 4.8      && < 4.13
+      base                    >= 4.9      && < 4.13
     , aeson                   >= 1.3.1.1  && < 1.5
     , base64-bytestring       >= 1.0.0.1  && < 1.1
     , blaze-builder           >= 0.4.1.0  && < 0.5

--- a/servant-auth-swagger/servant-auth-swagger.cabal
+++ b/servant-auth-swagger/servant-auth-swagger.cabal
@@ -15,7 +15,7 @@ maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
 license:        BSD3
 license-file:   LICENSE
-tested-with:    GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.2
+tested-with:    GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.2
 build-type:     Simple
 cabal-version:  >= 1.10
 extra-source-files:
@@ -31,7 +31,7 @@ library
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base            >= 4.8     && < 4.13
+      base            >= 4.9     && < 4.13
     , text            >= 1.2.3.0 && < 1.3
     , servant-swagger >= 1.1.5   && < 1.8
     , swagger2        >= 2.2.2   && < 2.4

--- a/servant-auth/servant-auth.cabal
+++ b/servant-auth/servant-auth.cabal
@@ -17,7 +17,7 @@ maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
 license:        BSD3
 license-file:   LICENSE
-tested-with:    GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC==8.4.4, GHC==8.6.2
+tested-with:    GHC == 8.0.2, GHC == 8.2.2, GHC==8.4.4, GHC==8.6.2
 build-type:     Simple
 cabal-version:  >= 1.10
 extra-source-files:
@@ -33,7 +33,7 @@ library
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base    >= 4.8  && < 4.13
+      base    >= 4.9  && < 4.13
     , servant >= 0.13 && < 0.17
   exposed-modules:
       Servant.Auth


### PR DESCRIPTION
Fix #144 

@phadej should we mention in changelog that `GenResponse` is now `ResponseF`? This was public api in  `servant-client`