### PR TITLE
remove unused constraint in HasServer instance for Auth

### DIFF
--- a/servant-auth-server/src/Servant/Auth/Server/Internal.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal.hs
@@ -63,9 +63,7 @@ instance ( n ~ 'S ('S 'Z)
                 Just jwt -> return $ Just jwt `SetCookieCons` SetCookieNil
             _ -> return $ Nothing `SetCookieCons` SetCookieNil
 
-      go :: ( old ~ ServerT api Handler
-            , new ~ ServerT (AddSetCookiesApi n api) Handler
-            )
-         => (AuthResult v -> ServerT api Handler)
-         -> (AuthResult v, SetCookieList n) -> new
+      go :: (AuthResult v -> ServerT api Handler)
+         -> (AuthResult v, SetCookieList n)
+         -> ServerT (AddSetCookiesApi n api) Handler
       go fn (authResult, cookies) = addSetCookies cookies $ fn authResult


### PR DESCRIPTION
There is an unused constraint in the `HasServer` instance for `Auth`, so this PR removes it.

I also took the liberty to further simplify the type signature.