### PR TITLE
Extract fail method from Monad AuthCheck

### DIFF
--- a/servant-auth-server/src/Servant/Auth/Server/Internal/Types.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/Types.hs
@@ -75,7 +75,6 @@ instance Applicative AuthCheck where
 
 instance Monad AuthCheck where
   return = AuthCheck . return . return . return
-  fail _ = AuthCheck . const $ return Indefinite
   AuthCheck ac >>= f = AuthCheck $ \req -> do
     aresult <- ac req
     case aresult of
@@ -83,6 +82,9 @@ instance Monad AuthCheck where
       BadPassword       -> return BadPassword
       NoSuchUser        -> return NoSuchUser
       Indefinite        -> return Indefinite
+
+instance MonadFail AuthCheck where
+  fail _ = AuthCheck . const $ return Indefinite
 
 instance MonadReader Request AuthCheck where
   ask = AuthCheck $ \x -> return (Authenticated x)


### PR DESCRIPTION
Small fix to get this working with 8.8.1.