### PR TITLE
Document BasicAuthCfg

### DIFF
--- a/servant-auth-server/src/Servant/Auth/Server/Internal/BasicAuth.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/BasicAuth.hs
@@ -19,6 +19,31 @@ import Servant.Auth.Server.Internal.Types
 wwwAuthenticatedErr :: BS.ByteString -> ServerError
 wwwAuthenticatedErr realm = err401 { errHeaders = [mkBAChallengerHdr realm] }
 
+-- | A type holding the configuration for Basic Authentication. 
+-- It is defined as a type family with no arguments, so that
+-- it can be instantiated to whatever type you need to
+-- authenticate your users (use @type instance BasicAuthCfg = ...@).
+-- 
+-- Note that the instantiation is application-wide,
+-- i.e. there can be only one instance.
+-- As a consequence, it should not be instantiated in a library.
+-- 
+-- Basic Authentication expects an element of type 'BasicAuthCfg'
+-- to be in the 'Context'; that element is then passed automatically
+-- to the instance of 'FromBasicAuthData' together with the
+-- authentication data obtained from the client.
+-- 
+-- If you do not need a configuration for Basic Authentication,
+-- you can use just @BasicAuthCfg = ()@, and recall to also
+-- add @()@ to the 'Context'.
+-- A basic but more interesting example is to take as 'BasicAuthCfg' 
+-- a list of authorised username/password pairs:
+-- 
+-- > deriving instance Eq BasicAuthData
+-- > type instance BasicAuthCfg = [BasicAuthData]
+-- > instance FromBasicAuthData User where
+-- >   fromBasicAuthData authData authCfg =
+-- >     if elem authData authCfg then ...
 type family BasicAuthCfg
 
 class FromBasicAuthData a where


### PR DESCRIPTION
This PR just adds documentation to `BasicAuthCfg`, the type used for configuring Basic Authentication.

The definition of `BasicAuthCfg` as a type family without arguments may surprise new users, so I added a short explanation. I also added a couple of simple usage examples.