### PR TITLE
First pass: move ToJWT/FromJWT to servant-auth

### DIFF
--- a/servant-auth-server/src/Servant/Auth/Server.hs
+++ b/servant-auth-server/src/Servant/Auth/Server.hs
@@ -142,6 +142,7 @@ import Prelude hiding                           (readFile, writeFile)
 import Data.ByteString                          (ByteString, writeFile, readFile)
 import Data.Default.Class                       (Default (def))
 import Servant.Auth
+import Servant.Auth.JWT
 import Servant.Auth.Server.Internal             ()
 import Servant.Auth.Server.Internal.BasicAuth
 import Servant.Auth.Server.Internal.Class

--- a/servant-auth-server/src/Servant/Auth/Server/Internal.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal.hs
@@ -9,6 +9,7 @@ import           Servant             ((:>), Handler, HasServer (..),
                                       Proxy (..),
                                       HasContextEntry(getContextEntry))
 import           Servant.Auth
+import           Servant.Auth.JWT    (ToJWT)
 
 import Servant.Auth.Server.Internal.AddSetCookie
 import Servant.Auth.Server.Internal.Class

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/Class.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/Class.hs
@@ -5,11 +5,12 @@ import Servant.Auth
 import Data.Monoid
 import Servant hiding (BasicAuth)
 
+import Servant.Auth.JWT
 import Servant.Auth.Server.Internal.Types
 import Servant.Auth.Server.Internal.ConfigTypes
 import Servant.Auth.Server.Internal.BasicAuth
 import Servant.Auth.Server.Internal.Cookie
-import Servant.Auth.Server.Internal.JWT
+import Servant.Auth.Server.Internal.JWT (jwtAuthCheck)
 
 -- | @IsAuth a ctx v@ indicates that @a@ is an auth type that expects all
 -- elements of @ctx@ to be the in the Context and whose authentication check

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
@@ -20,9 +20,9 @@ import           Servant                  (AddHeader, addHeader)
 import           System.Entropy           (getEntropy)
 import           Web.Cookie
 
+import Servant.Auth.JWT                          (FromJWT (decodeJWT), ToJWT)
 import Servant.Auth.Server.Internal.ConfigTypes
-import Servant.Auth.Server.Internal.JWT         (FromJWT (decodeJWT), ToJWT,
-                                                 makeJWT)
+import Servant.Auth.Server.Internal.JWT          (makeJWT)
 import Servant.Auth.Server.Internal.Types
 
 

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/JWT.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/JWT.hs
@@ -16,32 +16,10 @@ import qualified Data.Text            as T
 import           Data.Time            (UTCTime)
 import           Network.Wai          (requestHeaders)
 
+import Servant.Auth.JWT               (FromJWT(..), ToJWT(..))
 import Servant.Auth.Server.Internal.ConfigTypes
 import Servant.Auth.Server.Internal.Types
 
--- This should probably also be from ClaimSet
---
--- | How to decode data from a JWT.
---
--- The default implementation assumes the data is stored in the unregistered
--- @dat@ claim, and uses the @FromJSON@ instance to decode value from there.
-class FromJWT a where
-  decodeJWT :: Jose.ClaimsSet -> Either T.Text a
-  default decodeJWT :: FromJSON a => Jose.ClaimsSet -> Either T.Text a
-  decodeJWT m = case HM.lookup "dat" (m ^. Jose.unregisteredClaims) of
-    Nothing -> Left "Missing 'dat' claim"
-    Just v  -> case fromJSON v of
-      Error e -> Left $ T.pack e
-      Success a -> Right a
-
--- | How to encode data from a JWT.
---
--- The default implementation stores data in the unregistered @dat@ claim, and
--- uses the type's @ToJSON@ instance to encode the data.
-class ToJWT a where
-  encodeJWT :: a -> Jose.ClaimsSet
-  default encodeJWT :: ToJSON a => a -> Jose.ClaimsSet
-  encodeJWT a = Jose.addClaim "dat" (toJSON a) Jose.emptyClaimsSet
 
 -- | A JWT @AuthCheck@. You likely won't need to use this directly unless you
 -- are protecting a @Raw@ endpoint.

--- a/servant-auth/servant-auth.cabal
+++ b/servant-auth/servant-auth.cabal
@@ -33,8 +33,14 @@ library
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base    >= 4.9  && < 4.14
-    , servant >= 0.15 && < 0.18
+      base                    >= 4.9      && < 4.14
+    , aeson                   >= 1.3.1.1  && < 1.5
+    , jose                    >= 0.7.0.0  && < 0.9
+    , lens                    >= 4.16.1   && < 4.19
+    , servant                 >= 0.15     && < 0.18
+    , text                    >= 1.2.3.0  && < 1.3
+    , unordered-containers    >= 0.2.9.0  && < 0.3
   exposed-modules:
       Servant.Auth
+      Servant.Auth.JWT
   default-language: Haskell2010

--- a/servant-auth/src/Servant/Auth/JWT.hs
+++ b/servant-auth/src/Servant/Auth/JWT.hs
@@ -1,0 +1,33 @@
+module Servant.Auth.JWT where
+
+import           Control.Lens         ((^.))
+import qualified Crypto.JWT           as Jose
+import           Data.Aeson           (FromJSON, Result (..), ToJSON, fromJSON,
+                                       toJSON)
+import qualified Data.HashMap.Strict  as HM
+import qualified Data.Text            as T
+
+
+-- This should probably also be from ClaimSet
+--
+-- | How to decode data from a JWT.
+--
+-- The default implementation assumes the data is stored in the unregistered
+-- @dat@ claim, and uses the @FromJSON@ instance to decode value from there.
+class FromJWT a where
+  decodeJWT :: Jose.ClaimsSet -> Either T.Text a
+  default decodeJWT :: FromJSON a => Jose.ClaimsSet -> Either T.Text a
+  decodeJWT m = case HM.lookup "dat" (m ^. Jose.unregisteredClaims) of
+    Nothing -> Left "Missing 'dat' claim"
+    Just v  -> case fromJSON v of
+      Error e -> Left $ T.pack e
+      Success a -> Right a
+
+-- | How to encode data from a JWT.
+--
+-- The default implementation stores data in the unregistered @dat@ claim, and
+-- uses the type's @ToJSON@ instance to encode the data.
+class ToJWT a where
+  encodeJWT :: a -> Jose.ClaimsSet
+  default encodeJWT :: ToJSON a => a -> Jose.ClaimsSet
+  encodeJWT a = Jose.addClaim "dat" (toJSON a) Jose.emptyClaimsSet


### PR DESCRIPTION
I was experimenting with various things in this library this morning, and I saw issue #135 and thought to try to put together a solution.

I reexported `ToJWT` and `FromJWT` from `servant-auth-server` to keep things consistent for users. 

Fixes #135 