### PR TITLE
Fix: AnySite

### DIFF
--- a/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Servant.Auth.Server.Internal.Cookie where
 
 import           Blaze.ByteString.Builder (toByteString)
@@ -120,11 +121,17 @@ applySessionCookieSettings :: CookieSettings -> SetCookie -> SetCookie
 applySessionCookieSettings cookieSettings setCookie = setCookie
   { setCookieName = sessionCookieName cookieSettings
   , setCookieSameSite = case cookieSameSite cookieSettings of
-      AnySite -> Nothing
+      AnySite -> anySite
       SameSiteStrict -> Just sameSiteStrict
       SameSiteLax -> Just sameSiteLax
   , setCookieHttpOnly = True
   }
+  where
+#if MIN_VERSION_cookie(0,4,5)
+    anySite = Just sameSiteNone
+#else
+    anySite = Nothing
+#endif
 
 -- | For a JWT-serializable session, returns a function that decorates a
 -- provided response object with XSRF and session cookies. This should be used


### PR DESCRIPTION
`AnySite` in `CookieSettings` doesn't work. It was consequence from lack of such setting in the `cookie` package in the past.

But now there is `sameSiteNone` option for Cookies (`cookie >= 0.4.5`) which is corresponding to `AnySite`. So this patch fix it.