### PR TITLE
Updates CI and README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,87 +4,99 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [master]
+    # TODO: revert this to just `master` before merge.
+    branches: ['master', 'ci']
 
 jobs:
-  cabal:
-    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macOS-latest]
-        ghc:
-          - "8.2"
-          - "8.4"
-          - "8.6"
-          - "8.8"
-          - "8.10"
-        exclude:
-          - os: macOS-latest
-            ghc: 8.8.3
-          - os: macOS-latest
-            ghc: 8.6.5
+  # cabal:
+  #   name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, macOS-latest]
+  #       ghc:
+  #         - '8.2'
+  #         - '8.4'
+  #         - '8.6'
+  #         - '8.8'
+  #         - '8.10'
+  #       exclude:
+  #         - os: macOS-latest
+  #           ghc: 8.8.3
+  #         - os: macOS-latest
+  #           ghc: 8.6.5
 
-    steps:
-    - uses: actions/checkout@v2
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #     if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: bubba/setup-haskell@2215b2c
-      id: setup-haskell-cabal
-      name: Setup Haskell
-      with:
-        ghc-version: ${{ matrix.ghc }}
+  #   - uses: haskell/actions/setup@v1
+  #     id: setup-haskell-cabal
+  #     name: Setup Haskell
+  #     with:
+  #       ghc-version: ${{ matrix.ghc }}
 
-    - name: Freeze
-      run: |
-        cabal freeze
+  #   - name: Freeze
+  #     run: |
+  #       cabal freeze
 
-    - uses: actions/cache@v1
-      name: Cache ~/.cabal/store
-      with:
-        path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+  #   - uses: actions/cache@v1
+  #     name: Cache ~/.cabal/store
+  #     with:
+  #       path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+  #       key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
 
-    - name: Build
-      run: |
-        cabal configure --enable-tests --enable-benchmarks --test-show-details=direct
-        cabal build all
+  #   - name: Build
+  #     run: |
+  #       cabal configure --enable-tests --enable-benchmarks --test-show-details=direct
+  #       cabal build all
 
-    - name: Test
-      run: |
-        cabal test all
+  #   - name: Test
+  #     run: |
+  #       cabal test all
 
-    - name: Haddock
-      run: |
-        cabal haddock all
+  #   - name: Haddock
+  #     run: |
+  #       cabal haddock all
+
   stack:
-    name: stack / ghc ${{ matrix.ghc }}
+    name: stack ${{ matrix.name }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        stack: ["2.3.1"]
-        ghc: ["8.10.2"]
+        os: ['ubuntu-latest']
+        name: ['nightly', 'lts16']
+        include:
+          # Check that the build passes with the nightly snapshot.
+          - name: 'nightly'
+            stack_yaml: 'stack.yaml'
+          # Check that the build passes with the latest LTS snapshot.
+          - name: 'lts16'
+            stack_yaml: 'stack-lts16.yaml'
 
     steps:
     - uses: actions/checkout@v2
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
+      # if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: bubba/setup-haskell@2215b2c
-      name: Setup Haskell Stack
+    - uses: actions/cache@v2
+      name: Cache Stack Artifacts
       with:
-        ghc-version: ${{ matrix.ghc }}
-        stack-version: ${{ matrix.stack }}
+        path: |
+          ~/.stack
+          .stack-work
+        key: ${{ runner.os }}-stack-${{ hashFiles(matrix.stack_yaml) }}
 
-    - uses: actions/cache@v1
-      name: Cache ~/.stack
+    - uses: haskell/actions/setup@v1
+      name: Stack Setup
       with:
-        path: ~/.stack
-        key: ${{ runner.os }}-${{ matrix.ghc }}-stack
+        enable-stack: true
+        stack-no-global: true
+        stack-setup-ghc: true
 
     - name: Build
       run: |
-        stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks
+        stack --stack-yaml=${{ matrix.stack_yaml }} build --test --bench --no-run-tests --no-run-benchmarks
 
     - name: Test
       run: |
-        stack test --system-ghc
+        stack --stack-yaml=${{ matrix.stack_yaml }} test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,56 +12,54 @@ on:
     - cron: '0 0 1 * *'
 
 jobs:
-  # cabal:
-  #   name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, macOS-latest]
-  #       ghc:
-  #         - '8.2'
-  #         - '8.4'
-  #         - '8.6'
-  #         - '8.8'
-  #         - '8.10'
-  #       exclude:
-  #         - os: macOS-latest
-  #           ghc: 8.8.3
-  #         - os: macOS-latest
-  #           ghc: 8.6.5
+  cabal:
+    name: ghc ${{ matrix.ghc }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['ubuntu-latest']
+        # Check the last 3 (or so) major GHC releases; no need to waste compute.
+        ghc: ['8.6.5', '8.8.4', '8.10.3']
 
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #     if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
+    steps:
+    - uses: actions/checkout@v2
+      # TODO: Revert this before merging.
+      # if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
 
-  #   - uses: haskell/actions/setup@v1
-  #     id: setup-haskell-cabal
-  #     name: Setup Haskell
-  #     with:
-  #       ghc-version: ${{ matrix.ghc }}
+    - uses: haskell/actions/setup@v1
+      id: setup-haskell-cabal
+      name: Setup Cabal
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
 
-  #   - name: Freeze
-  #     run: |
-  #       cabal freeze
+    # Regenerate the freeze file on each run to ensure that `cabal-install`
+    # always builds against the latest dependencies.
+    - name: Freeze
+      run: |
+        cabal configure --enable-tests --enable-benchmarks --test-show-details=direct
+        cabal freeze
 
-  #   - uses: actions/cache@v1
-  #     name: Cache ~/.cabal/store
-  #     with:
-  #       path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-  #       key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+    - uses: actions/cache@v2
+      name: Cache Cabal Artifacts
+      with:
+        path: |
+          ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+          dist-newstyle
+        key: ${{ runner.os }}-cabal-${{ hashFiles('cabal.project.freeze') }}
 
-  #   - name: Build
-  #     run: |
-  #       cabal configure --enable-tests --enable-benchmarks --test-show-details=direct
-  #       cabal build all
 
-  #   - name: Test
-  #     run: |
-  #       cabal test all
+    - name: Build
+      run: |
+        cabal build all
 
-  #   - name: Haddock
-  #     run: |
-  #       cabal haddock all
+    - name: Test
+      run: |
+        cabal test all
+
+    - name: Generate Documentation
+      run: |
+        cabal haddock all
 
   stack:
     name: stack ${{ matrix.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   # ...and when the main branch is updated.
   push:
     # TODO: Revert this before merging.
-    branches: ['master', 'ci']
+    branches: ['master']
   # Build _at least_ once per month to actively check for regressions.
   schedule:
     - cron: '0 0 1 * *'
@@ -23,8 +23,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      # TODO: Revert this before merging.
-      # if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
+      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
 
     - uses: haskell/actions/setup@v1
       id: setup-haskell-cabal
@@ -78,8 +77,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      # TODO: Revert this before merging.
-      # if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
+      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
     - uses: actions/cache@v2
       name: Cache Stack Artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,15 @@
 name: CI
 
-# Trigger the workflow on push or pull request, but only for the master branch
 on:
+  # Trigger the workflow on every pull request...
   pull_request:
+  # ...and when the main branch is updated.
   push:
-    # TODO: revert this to just `master` before merge.
+    # TODO: Revert this before merging.
     branches: ['master', 'ci']
+  # Build _at least_ once per month to actively check for regressions.
+  schedule:
+    - cron: '0 0 1 * *'
 
 jobs:
   # cabal:
@@ -61,7 +65,7 @@ jobs:
 
   stack:
     name: stack ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: ['ubuntu-latest']
@@ -76,6 +80,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      # TODO: Revert this before merging.
       # if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
     - uses: actions/cache@v2

--- a/servant-auth-client/servant-auth-client.cabal
+++ b/servant-auth-client/servant-auth-client.cabal
@@ -15,7 +15,7 @@ maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
 license:        BSD3
 license-file:   LICENSE
-tested-with:    GHC == 8.2.2, GHC==8.4.4, GHC==8.6.5, GHC==8.8.1, GHC==8.10.2
+tested-with:    GHC==8.6.5, GHC==8.8.4 GHC==8.10.3
 build-type:     Simple
 cabal-version:  >= 1.10
 extra-source-files:

--- a/servant-auth-docs/servant-auth-docs.cabal
+++ b/servant-auth-docs/servant-auth-docs.cabal
@@ -15,7 +15,7 @@ maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
 license:        BSD3
 license-file:   LICENSE
-tested-with:    GHC == 8.2.2, GHC==8.4.4, GHC==8.6.5, GHC==8.8.1
+tested-with:    GHC==8.6.5, GHC==8.8.4 GHC==8.10.3
 build-type:     Custom
 cabal-version:  >= 1.10
 extra-source-files:

--- a/servant-auth-server/README.lhs
+++ b/servant-auth-server/README.lhs
@@ -1,6 +1,6 @@
 # servant-auth
 
-![CI](https://github.com/haskell-servant/servant-auth/workflows/CI/badge.svg)
+[![build status](https://img.shields.io/github/workflow/status/haskell-servant/servant-auth/CI/master?style=flat-square&logo=github&label=build%20status)](https://github.com/haskell-servant/servant-auth/actions?query=workflow%3ACI)
 
 These packages provides safe and easy-to-use authentication options for
 `servant`. The same API can be protected via:
@@ -9,13 +9,13 @@ These packages provides safe and easy-to-use authentication options for
 - JWT tokens
 
 
-| Package              | Hackage                                                                                                                           |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| servant-auth         | [![Hackage](https://img.shields.io/hackage/v/servant-auth.svg)](https://hackage.haskell.org/package/servant-auth)                 |
-| servant-auth-server  | [![Hackage](https://img.shields.io/hackage/v/servant-auth-server.svg)](https://hackage.haskell.org/package/servant-auth-server)   |
-| servant-auth-client  | [![Hackage](https://img.shields.io/hackage/v/servant-auth-client.svg)](https://hackage.haskell.org/package/servant-auth-client)   |
-| servant-auth-swagger | [![Hackage](https://img.shields.io/hackage/v/servant-auth-swagger.svg)](https://hackage.haskell.org/package/servant-auth-swagger) |
-| servant-auth-docs    | [![Hackage](https://img.shields.io/hackage/v/servant-auth-docs.svg)](https://hackage.haskell.org/package/servant-auth-docs)       |
+| Package              | Hackage                                                                                                                                                                                               |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| servant-auth         | [![servant-auth](https://img.shields.io/hackage/v/servant-auth?style=flat-square&logo=haskell&label&labelColor=5D4F85)](https://hackage.haskell.org/package/servant-auth)                             |
+| servant-auth-server  | [![servant-auth-server](https://img.shields.io/hackage/v/servant-auth-server.svg?style=flat-square&logo=haskell&label&labelColor=5D4F85)](https://hackage.haskell.org/package/servant-auth-server)    |
+| servant-auth-client  | [![servant-auth-client](https://img.shields.io/hackage/v/servant-auth-client.svg?style=flat-square&logo=haskell&label&labelColor=5D4F85)](https://hackage.haskell.org/package/servant-auth-client)    |
+| servant-auth-swagger | [![servant-auth-swagger](https://img.shields.io/hackage/v/servant-auth-swagger.svg?style=flat-square&logo=haskell&label&labelColor=5D4F85)](https://hackage.haskell.org/package/servant-auth-swagger) |
+| servant-auth-docs    | [![servant-auth-docs](https://img.shields.io/hackage/v/servant-auth-docs.svg?style=flat-square&logo=haskell&label&labelColor=5D4F85)](https://hackage.haskell.org/package/servant-auth-docs)          |
 
 ## How it works
 

--- a/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth-server/servant-auth-server.cabal
@@ -15,7 +15,7 @@ maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
 license:        BSD3
 license-file:   LICENSE
-tested-with:    GHC == 8.2.2, GHC==8.4.4, GHC==8.6.5, GHC==8.8.1, GHC==8.10.2
+tested-with:    GHC==8.6.5, GHC==8.8.1, GHC==8.10.3
 build-type:     Simple
 cabal-version:  >= 1.10
 extra-source-files:

--- a/servant-auth-swagger/servant-auth-swagger.cabal
+++ b/servant-auth-swagger/servant-auth-swagger.cabal
@@ -15,7 +15,7 @@ maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
 license:        BSD3
 license-file:   LICENSE
-tested-with:    GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.1, GHC==8.10.2
+tested-with:    GHC == 8.6.5, GHC == 8.8.1, GHC==8.10.3
 build-type:     Simple
 cabal-version:  >= 1.10
 extra-source-files:

--- a/servant-auth/servant-auth.cabal
+++ b/servant-auth/servant-auth.cabal
@@ -17,7 +17,7 @@ maintainer:     jkarni@gmail.com
 copyright:      (c) Julian K. Arni
 license:        BSD3
 license-file:   LICENSE
-tested-with:    GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.1, GHC == 8.10.2
+tested-with:    GHC==8.6.5, GHC==8.8.4 GHC==8.10.3
 build-type:     Simple
 cabal-version:  >= 1.10
 extra-source-files:

--- a/stack-lts16.yaml
+++ b/stack-lts16.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-12-14
+resolver: lts-16.27
 packages:
 - servant-auth
 - servant-auth-server


### PR DESCRIPTION
I've made some updates to the `servant-auth` CI setup to try and bring them up to speed with the official [haskell/actions](github.com/haskell/actions) GitHub Actions (since neither [bubba/setup-haskell](github.com/bubba/setup-haskell) or [actions/haskell](github.com/actions/setup-haskell) are actively maintained).

Aside from just doing a little cleaning, I've also made the following opinionated changes:
- dropped the macOS runners
  - since this is a library (and not an application) without any dynamic library or C deps, having the extra runners just seemed like more noise in the matrix
- dropped GHC 8.2 and 8.4
  - I don't typically see much point in actively supporting GHC versions older than the last 3 major releases
  - that being said, I guess compute is pretty cheap; if y'all would prefer to continue checking against GHC 8.2.2 and 8.4.4 then I can just add them back to the matrix
- updated the nightly Stackage snapshot
- added a Stackage LTS runner
- updated the README badges
  - mostly just stylistic changes (e.g. using the Haskell logo and label color)

---

Rendered badge updates:
![Screen Shot 2020-12-31 at 6 18 46 PM](https://user-images.githubusercontent.com/8461423/103430700-97591800-4bbe-11eb-8701-242fb49315c1.png)

Looking at it a bit more, the orange-on-white contrast is slightly distracting; maybe it would be better if the whole badge was Haskell-purple?