### PR TITLE
Fixes cabal-install action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
   # ...and when the main branch is updated.
   push:
-    # TODO: Revert this before merging.
     branches: ['master']
   # Build _at least_ once per month to actively check for regressions.
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
+      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
     - uses: haskell/actions/setup@v1
       id: setup-haskell-cabal


### PR DESCRIPTION
#182 had a copy/paste error from another project that uses "main" as the branch name which prevents the `checkout` action from running normally on the main project.