### PR TITLE
Fixes GitHub Actions-based CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   # ...and when the main branch is updated.
   push:
-    branches: ['master']
+    # branches: ['master']
   # Build _at least_ once per month to actively check for regressions.
   schedule:
     - cron: '0 0 1 * *'
@@ -18,11 +18,11 @@ jobs:
       matrix:
         os: ['ubuntu-18.04']
         # Check the last 3 (or so) major GHC releases; no need to waste compute.
-        ghc: ['8.6.5', '8.8.4', '8.10.3']
+        ghc: ['8.6.5', '8.8.4', '8.10.4']
 
     steps:
     - uses: actions/checkout@v2
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
+      # if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
     - uses: haskell/actions/setup@v1
       id: setup-haskell-cabal
@@ -64,7 +64,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest']
+        os: ['ubuntu-18.04']
         name: ['nightly', 'lts16']
         include:
           # Check that the build passes with the nightly snapshot.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         # Check the last 3 (or so) major GHC releases; no need to waste compute.
-        ghc: ['8.6.5', '8.8.4', '8.10.4', '9.0.1']
+        ghc: ['8.6.5', '8.8.4', '8.10.4']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,56 +16,55 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-18.04']
+        os: ['ubuntu-latest']
         # Check the last 3 (or so) major GHC releases; no need to waste compute.
-        ghc: ['8.6.5', '8.8.4', '8.10.4']
+        ghc: ['8.6.5', '8.8.4', '8.10.4', '9.0.1']
 
     steps:
-    - uses: actions/checkout@v2
-      # if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
+      - uses: actions/checkout@v2
 
-    - uses: haskell/actions/setup@v1
-      id: setup-haskell-cabal
-      name: Setup Cabal
-      with:
-        ghc-version: ${{ matrix.ghc }}
-        cabal-version: ${{ matrix.cabal }}
+      - uses: haskell/actions/setup@v1
+        id: setup-haskell-cabal
+        name: Setup Cabal
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
 
-    # Regenerate the freeze file on each run to ensure that `cabal-install`
-    # always builds against the latest dependencies.
-    - name: Freeze
-      run: |
-        cabal configure --enable-tests --enable-benchmarks --test-show-details=direct
-        cabal freeze
+      # Regenerate the freeze file on each run to ensure that `cabal-install`
+      # always builds against the latest dependencies.
+      - name: Freeze
+        run: |
+          cabal configure --enable-tests --enable-benchmarks --test-show-details=direct
+          cabal freeze
 
-    - uses: actions/cache@v2
-      name: Cache Cabal Artifacts
-      with:
-        path: |
-          ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-          dist-newstyle
-        key: ${{ runner.os }}-cabal-${{ hashFiles('cabal.project.freeze') }}
+      - uses: actions/cache@v2
+        name: Cache Cabal Artifacts
+        with:
+          path: |
+            ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+            dist-newstyle
+          key: ${{ runner.os }}-cabal-${{ hashFiles('cabal.project.freeze') }}
 
 
-    - name: Build
-      run: |
-        cabal build all
+      - name: Build
+        run: |
+          cabal build all
 
-    - name: Test
-      run: |
-        cabal test all
+      - name: Test
+        run: |
+          cabal test all
 
-    - name: Generate Documentation
-      run: |
-        cabal haddock all
+      - name: Generate Documentation
+        run: |
+          cabal haddock all
 
   stack:
     name: stack ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-18.04']
-        name: ['nightly', 'lts16']
+        os: ['ubuntu-latest']
+        name: ['nightly', 'lts16', 'lts17']
         include:
           # Check that the build passes with the nightly snapshot.
           - name: 'nightly'
@@ -73,30 +72,32 @@ jobs:
           # Check that the build passes with the latest LTS snapshot.
           - name: 'lts16'
             stack_yaml: 'stack-lts16.yaml'
+          # Check that the build passes with the latest LTS snapshot.
+          - name: 'lts17'
+            stack_yaml: 'stack-lts17.yaml'
 
     steps:
-    - uses: actions/checkout@v2
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
+      - uses: actions/checkout@v2
 
-    - uses: actions/cache@v2
-      name: Cache Stack Artifacts
-      with:
-        path: |
-          ~/.stack
-          .stack-work
-        key: ${{ runner.os }}-stack-${{ hashFiles(matrix.stack_yaml) }}
+      - uses: actions/cache@v2
+        name: Cache Stack Artifacts
+        with:
+          path: |
+            ~/.stack
+            .stack-work
+          key: ${{ runner.os }}-stack-${{ hashFiles(matrix.stack_yaml) }}
 
-    - uses: haskell/actions/setup@v1
-      name: Stack Setup
-      with:
-        enable-stack: true
-        stack-no-global: true
-        stack-setup-ghc: true
+      - uses: haskell/actions/setup@v1
+        name: Stack Setup
+        with:
+          enable-stack: true
+          stack-no-global: true
+          stack-setup-ghc: true
 
-    - name: Build
-      run: |
-        stack --stack-yaml=${{ matrix.stack_yaml }} build --test --bench --no-run-tests --no-run-benchmarks
+      - name: Build
+        run: |
+          stack --stack-yaml=${{ matrix.stack_yaml }} build --test --bench --no-run-tests --no-run-benchmarks
 
-    - name: Test
-      run: |
-        stack --stack-yaml=${{ matrix.stack_yaml }} test
+      - name: Test
+        run: |
+          stack --stack-yaml=${{ matrix.stack_yaml }} test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   # ...and when the main branch is updated.
   push:
-    # branches: ['master']
+    branches: ['master']
   # Build _at least_ once per month to actively check for regressions.
   schedule:
     - cron: '0 0 1 * *'

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,9 +1,0 @@
-branches: master
-
-constraint-set servant-0.15
-  ghc: >= 8.0 && <8.8
-  constraints: servant ==0.15.*
-
-constraint-set servant-0.16
-  ghc: >= 8.0 && <8.8
-  constraints: servant ==0.16.*

--- a/stack-lts16.yaml
+++ b/stack-lts16.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.27
+resolver: lts-16.31
 packages:
 - servant-auth
 - servant-auth-server

--- a/stack-lts17.yaml
+++ b/stack-lts17.yaml
@@ -1,0 +1,7 @@
+resolver: lts-17.5
+packages:
+- servant-auth
+- servant-auth-server
+- servant-auth-client
+- servant-auth-docs
+- servant-auth-swagger

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-12-14
+resolver: nightly-2021-03-09
 packages:
 - servant-auth
 - servant-auth-server


### PR DESCRIPTION
It looks like there were some issues with my last attempt at fixing the GitHub Actions-based CI (cf #183).

This PR should _hopefully_ address it by fixing the criteria under which the checkout action runs (I copy/pasted from another project without fully understanding what it was doing).

In addition to that, I've added a CI step to check against the latest Stackage LTS (17.5 at the time of writing), and I've bumped the LTS-16 and nightly resolvers to newer versions as well.