### PR TITLE
Make "Set-Cookie" header in the response optional

### DIFF
--- a/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
@@ -57,9 +57,11 @@ defaultJWTSettings k = JWTSettings
 -- not testing over HTTPS.
 data CookieSettings = CookieSettings
   {
+  -- | If any "Set-Cookie" header will be generated. Default: @True@.
+    cookieIsUsed      :: !Bool
   -- | 'Secure' means browsers will only send cookies over HTTPS. Default:
   -- @Secure@.
-    cookieIsSecure    :: !IsSecure
+  , cookieIsSecure    :: !IsSecure
   -- | How long from now until the cookie expires. Default: @Nothing@.
   , cookieMaxAge      :: !(Maybe DiffTime)
   -- | At what time the cookie expires. Default: @Nothing@.
@@ -81,7 +83,8 @@ instance Default CookieSettings where
 
 defaultCookieSettings :: CookieSettings
 defaultCookieSettings = CookieSettings
-    { cookieIsSecure    = Secure
+    { cookieIsUsed      = True
+    , cookieIsSecure    = Secure
     , cookieMaxAge      = Nothing
     , cookieExpires     = Nothing
     , cookiePath        = Just "/"


### PR DESCRIPTION
I noticed that often it's not needed to pass a JWT token in cookie. 
A field is added to `CookieSettings` to let the used specify whether to generate `Set-Cookie` headers. The default value for it is `True`, so the default behavior is kept the same as prevoius versions.
I made as little change as possible to add this feature.