### PR TITLE
Fix a JS example

### DIFF
--- a/servant-auth-server/README.lhs
+++ b/servant-auth-server/README.lhs
@@ -252,7 +252,7 @@ reading the cookie. For jQuery, and with the default values, that might be:
 var token = (function() {
   r = document.cookie.match(new RegExp('XSRF-TOKEN=([^;]+)'))
   if (r) return r[1];
-)();
+})();
 
 
 $.ajaxPrefilter(function(opts, origOpts, xhr) {


### PR DESCRIPTION
JS example in `XSRF and the frontend` missed a `}`