### PR TITLE
Update code for making Jquery and XSRF play nicely

### DIFF
--- a/servant-auth-server/README.lhs
+++ b/servant-auth-server/README.lhs
@@ -249,15 +249,14 @@ reading the cookie. For jQuery, and with the default values, that might be:
 
 ~~~ javascript
 
-var token = (function() {
+var getXSRFToken = function() {
   r = document.cookie.match(new RegExp('XSRF-TOKEN=([^;]+)'))
   if (r) return r[1];
-})();
-
+};
 
 $.ajaxPrefilter(function(opts, origOpts, xhr) {
-  xhr.setRequestHeader('X-XSRF-TOKEN', token);
-  }
+  xhr.setRequestHeader('X-XSRF-TOKEN', getXSRFToken());
+});
 
 ~~~
 


### PR DESCRIPTION
We need to dynamically find and set the header on every request.

I did not check for `jquery` but in the case of `htmx`:

The following does not work for multiple consecutive requests,
```
var token = (function() {
    r = document.cookie.match(new RegExp('XSRF-TOKEN=([^;]+)'))
    if (r) return r[1];
})();

document.body.addEventListener('htmx:configRequest', (event) => {
  event.detail.headers['X-XSRF-TOKEN'] = token;
});
```

The following does,
```
var getXSRFToken = function() {
    r = document.cookie.match(new RegExp('XSRF-TOKEN=([^;]+)'))
    if (r) return r[1];
};

document.body.addEventListener('htmx:configRequest', (event) => {
  event.detail.headers['X-XSRF-TOKEN'] = getXSRFToken();
});
```